### PR TITLE
Pass headers to config constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "aws-appsync": "^1.0.22",
     "node-fetch": "^2.1.2",
     "prop-types": "^15.6.1",
+    "lodash.isfunction": "^3.0.8",
     "react": "^16.4.0",
     "react-apollo": "^2.1.4",
     "react-dom": "^16.4.0"

--- a/src/initApollo.js
+++ b/src/initApollo.js
@@ -1,5 +1,6 @@
 import { AWSAppSyncClient } from "aws-appsync";
 import fetch from 'node-fetch'
+import isFunction from 'lodash.isfunction'
 
 let apolloClient = null
 
@@ -23,7 +24,11 @@ function create(initialState, appsyncConfig) {
   return client;
 }
 
-export default function initApollo(initialState, appsyncConfig) {
+export default function initApollo(initialState, appsyncConfig, headers) {
+  if (isFunction(appsyncConfig)) {
+    appsyncConfig = appsyncConfig(headers)
+  }
+
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
   if (!process.browser) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,6 +1236,10 @@ lodash-es@^4.17.4, lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
+lodash.isfunction@^3.0.8:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+
 lodash@4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"


### PR DESCRIPTION
This allows to dynamically configure authentication on the AppSync client based on the headers of the request.

Signed-off-by: fermayo <fermayo@gmail.com>