### PR TITLE
Add next as peer dependency, otherwise error on local build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "react": "^16.4.0",
     "react-apollo": "^2.1.4",
     "react-dom": "^16.4.0"
+  },
+  "peerDependencies": {
+    "next": "^7.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "next-apollo-appsync",
-  "version": "0.0.7",
+  "name": "@codelab/appsync",
+  "version": "0.0.1",
   "description": "Fork of next-apollo to enable AWS AppSync SSR Appsy",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "babel src --out-dir dist"
+    "build": "babel src --out-dir dist",
+    "dev": "babel src --watch --out-dir dist"
   },
   "files": [
     "dist"
@@ -17,10 +18,18 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1"
+    "babel-preset-react": "^6.24.1",
+    "eslint": "^5.12.1",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-plugin-import": "^2.15.0",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
+    "eslint-plugin-react": "^7.12.4"
   },
   "dependencies": {
+    "apollo-cache-inmemory": "^1.4.2",
+    "apollo-link-state": "^0.4.2",
     "aws-appsync": "^1.0.22",
+    "graphql-tag": "^2.10.1",
     "node-fetch": "^2.1.2",
     "prop-types": "^15.6.1",
     "react": "^16.4.0",

--- a/src/initApollo.js
+++ b/src/initApollo.js
@@ -1,6 +1,6 @@
-import { AWSAppSyncClient, createAppSyncLink } from 'aws-appsync';
-import fetch from 'node-fetch';
-import { ApolloLink } from 'apollo-link';
+import { AWSAppSyncClient, createAppSyncLink } from "aws-appsync";
+import fetch from "node-fetch";
+import { ApolloLink } from "apollo-link";
 
 let apolloClient = null;
 

--- a/src/withData.js
+++ b/src/withData.js
@@ -1,37 +1,37 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { ApolloProvider, getDataFromTree } from 'react-apollo'
-import Head from 'next/head'
-import initApollo from './initApollo'
+import React from "react";
+import PropTypes from "prop-types";
+import { ApolloProvider, getDataFromTree } from "react-apollo";
+import Head from "next/head";
+import initApollo from "./initApollo";
 
 // Gets the display name of a JSX component for dev tools
 function getComponentDisplayName(Component) {
-  return Component.displayName || Component.name || 'Unknown'
+  return Component.displayName || Component.name || "Unknown";
 }
 
-export default (appSyncConfig) => {
-  return (ComposedComponent) => {
+export default (appSyncConfig, stateLink) => {
+  return ComposedComponent => {
     return class WithData extends React.Component {
       static displayName = `WithData(${getComponentDisplayName(
         ComposedComponent
-      )})`
+      )})`;
       static propTypes = {
-        serverState: PropTypes.object.isRequired
-      }
-  
+        serverState: PropTypes.object.isRequired,
+      };
+
       static async getInitialProps(ctx) {
         // Initial serverState with apollo (empty)
-        let serverState
-  
+        let serverState;
+
         // Evaluate the composed component's getInitialProps()
-        let composedInitialProps = {}
+        let composedInitialProps = {};
         if (ComposedComponent.getInitialProps) {
-          composedInitialProps = await ComposedComponent.getInitialProps(ctx)
+          composedInitialProps = await ComposedComponent.getInitialProps(ctx);
         }
-  
+
         // Run all GraphQL queries in the component tree
         // and extract the resulting data
-        const apollo = initApollo(null, appSyncConfig)
+        const apollo = initApollo(null, appSyncConfig, stateLink);
         try {
           // create the url prop which is passed to every page
           const url = {
@@ -39,7 +39,7 @@ export default (appSyncConfig) => {
             asPath: ctx.asPath,
             pathname: ctx.pathname,
           };
-  
+
           // Run all GraphQL queries
           await getDataFromTree(
             <ComposedComponent ctx={ctx} url={url} {...composedInitialProps} />,
@@ -47,48 +47,52 @@ export default (appSyncConfig) => {
               router: {
                 asPath: ctx.asPath,
                 pathname: ctx.pathname,
-                query: ctx.query
+                query: ctx.query,
               },
-              client: apollo
+              client: apollo,
             }
-          )
+          );
         } catch (error) {
           // Prevent Apollo Client GraphQL errors from crashing SSR.
           // Handle them in components via the data.error prop:
           // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
         }
-  
+
         if (!process.browser) {
           // getDataFromTree does not call componentWillUnmount
           // head side effect therefore need to be cleared manually
-          Head.rewind()
+          Head.rewind();
         }
-  
+
         // Extract query data from the Apollo store
         serverState = {
           apollo: {
-            data: apollo.cache.extract()
-          }
-        }
-  
+            data: apollo.cache.extract(),
+          },
+        };
+
         return {
           serverState,
-          ...composedInitialProps
-        }
+          ...composedInitialProps,
+        };
       }
-  
+
       constructor(props) {
-        super(props)
-        this.apollo = initApollo(this.props.serverState.apollo.data, appSyncConfig)
+        super(props);
+        this.apollo = initApollo(
+          this.props.serverState.apollo.data,
+          appSyncConfig,
+          stateLink
+        );
       }
-  
+
       render() {
         return (
           <ApolloProvider client={this.apollo}>
             <ComposedComponent {...this.props} />
           </ApolloProvider>
-        )
+        );
       }
-    }
-  }
-}
+    };
+  };
+};


### PR DESCRIPTION
On a local build `import Head from "next/head";` in `withData.js` requires the `next` peerDependency to be listed

![withdata_ts_ _uib__workspace_](https://user-images.githubusercontent.com/26264925/51652028-02196780-1f43-11e9-958e-e34018ee637d.png)
